### PR TITLE
Implemented Task 3: HTTP Server with Calendar GET API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@
 - **Implementation of `getElementById('<id>')`**
 
 This is a simple web project that mimics the behavior of `document.getElementById` without actually using it. The DOM is traversed manually using recursion to find elements by their `id`.
+
+- **Simple Python HTTP Server with Calendar REST API**
+
+This project provides a lightweight HTTP server in Python that exposes a REST API endpoint to retrieve the current date and time, with optional filters for days, weeks, months, and years additions/subtractions.

--- a/kennect_http_server/.gitignore
+++ b/kennect_http_server/.gitignore
@@ -1,0 +1,2 @@
+kennect_http_servr.egg-info/
+build/

--- a/kennect_http_server/README.md
+++ b/kennect_http_server/README.md
@@ -1,0 +1,119 @@
+# Simple Python HTTP Server with Calendar REST API
+
+This project provides a lightweight HTTP server in Python that exposes a REST API endpoint to retrieve the current date and time, with optional filters for days, weeks, months, and years additions/subtractions.
+
+---
+
+## Features
+
+- REST API at `/datetime`
+- Query parameters:
+  - `days`
+  - `weeks`
+  - `months`
+  - `years`
+- Alters time from the current date based on query filters and returns results in ISO format
+- Built with Python’s HTTP standard library 
+
+---
+
+## 🛠️ Installation
+
+1. **Clone the repository:**
+
+```bash
+git clone https://github.com/yourusername/http_server_project.git
+cd http_server_project
+```
+
+2. **(Optional) Create a virtual environment:**
+
+```bash
+python -m venv venv
+source venv/bin/activate  # On Windows: venv\Scripts\activate
+```
+
+3. **Install the package locally:**
+
+```bash
+pip install .
+```
+
+---
+
+## Usage
+
+Run the server using the CLI:
+
+```bash
+runserver
+```
+
+By default, it will start on:
+[http://localhost:8080](http://localhost:8080)
+
+You can change the defaults at `config.py`
+
+---
+
+## API Usage
+
+**Endpoint:**
+
+```
+GET /datetime
+```
+
+**Optional query parameters:**
+
+| Parameter | Description       | Example     |
+| --------- | ----------------- | ----------- |
+| `seconds`   | Add/Subtract N weeks  | `?seconds=1`,`seconds=-3` |
+| `minutes`  | Add/Subtract N months | `?minutes=2`,`minutes=-3` |
+| `hours`   | Add/Subtract N years  | `?hours=1`,`hours=-3` |
+| `days`    | Add/Subtract N days   | `?days=3`,`days=-3`   |
+| `weeks`   | Add/Subtract N weeks  | `?weeks=1`,`weeks=-3` |
+| `months`  | Add/Subtract N months | `?months=2`,`months=-3` |
+| `years`   | Add/Subtract N years  | `?years=1`,`years=-3` |
+
+### 📌 Example:
+
+```bash
+curl "localhost:8080/datetime?date=2026-04-12T23:36:48.079852&days=5&months=1"
+```
+
+**Response:**
+
+```json
+"2026-04-12T23:36:48.079852"
+```
+
+```bash
+curl "localhost:8080/datetime?date=2026-04-12T23:36:48.079852&days=5&months=1&type=humanized"
+```
+
+**Response:**
+
+```json
+"12-Apr-2026 11:23:48"
+```
+
+---
+
+## 📌 Requirements
+
+* Python 3.7+
+
+---
+
+## 📄 License
+
+This project is unlicensed<br>
+Feel free to use and modify it!
+
+---
+
+## ✨ Author
+
+Developed by Savio Fernando
+

--- a/kennect_http_server/config.py
+++ b/kennect_http_server/config.py
@@ -1,0 +1,2 @@
+HOST = 'localhost'
+PORT = 8080

--- a/kennect_http_server/server.py
+++ b/kennect_http_server/server.py
@@ -1,0 +1,111 @@
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import config
+# import os
+from datetime import datetime, timedelta
+import traceback
+import json
+from urllib.parse import urlparse, parse_qs
+
+class DateTimeFormat():
+    HUMANIZED = "humanized"
+    ISOFORMAT = "default"
+
+
+def alter_date(
+    datetime_obj: datetime,
+    seconds: int = None,
+    minutes: int = None,
+    hours: int = None,
+    days: int = None,
+    weeks: int = None,
+    months: int = None,
+    years: int = None,
+) -> "Datetime":
+    """
+    Alter date based on arguments
+
+    :params
+    datetime_obj: datetime,
+    seconds: int
+    minutes: int
+    hours: int
+    days: int
+    weeks: int
+    months: int
+    years: int
+
+    :returns:
+    datetime: Altered datetime object
+
+    """
+    if seconds:
+        datetime_obj += timedelta(seconds=seconds)
+    if minutes:
+        datetime_obj += timedelta(minutes=minutes)
+    if hours:
+        datetime_obj += timedelta(hours=hours)
+    if days:
+        datetime_obj += timedelta(days=days)
+    if weeks:
+        datetime_obj += timedelta(weeks=weeks)
+    if months:
+        datetime_obj += timedelta(months=months)
+    if years:
+        datetime_obj += timedelta(days=365 * years)
+
+    return datetime_obj
+
+
+class CalendarAPI(BaseHTTPRequestHandler):
+    def do_GET(self):
+        try:
+            parsed_path = urlparse(self.path)
+            if parsed_path.path == "/datetime":
+                query_params = parse_qs(parsed_path.query)
+                date_type = query_params["type"][0] if "type" in query_params else DateTimeFormat.ISOFORMAT
+                if "date" in query_params:
+                    result = datetime.fromisoformat(query_params["date"][0])
+                else:
+                    result = datetime.now()
+                if "seconds" in query_params:
+                    result = alter_date(result, seconds=int(query_params["seconds"][0]))
+                if "minutes" in query_params:
+                    result = alter_date(result, minutes=int(query_params["minutes"][0]))
+                if "hours" in query_params:
+                   result = alter_date(result, hours=int(query_params["hours"][0]))
+                if "days" in query_params:
+                    result = alter_date(result, days=int(query_params["days"][0]))
+                if "weeks" in query_params:
+                    result = alter_date(result, weeks=int(query_params["weeks"][0]))
+                if "months" in query_params:
+                    result = alter_date(
+                        result, months=int(query_params["months"][0])
+                    )
+                if "years" in query_params:
+                    result = alter_date(result, years=int(query_params["years"][0]))
+                if date_type == DateTimeFormat.HUMANIZED:
+                    result = datetime.strftime(result, "%d-%b-%Y %I:%H:%S")
+                else:
+                    result = result.isoformat()
+                self.send_response(200)
+                self.send_header("Content-type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps(result, indent=2).encode())
+            else:
+                self.send_error(404, "Endpoint not found.")
+        except Exception as e:
+            self.send_error(
+                500,
+                f"Internal Server Error\n\n{traceback.print_exc()}",
+            )
+
+
+def run():
+    server_address = (config.HOST, config.PORT)
+    httpd = HTTPServer(server_address, CalendarAPI)
+    print(f"Serving on http://{config.HOST}:{config.PORT}")
+    httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    run()

--- a/kennect_http_server/setup.py
+++ b/kennect_http_server/setup.py
@@ -1,0 +1,17 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='kennect_http_server',
+    version='1.0.0',
+    description='A simple Python HTTP server that handles Calendar GET requests',
+    author='Savio Fernando',
+    packages=find_packages(),
+    py_modules=['server', 'config'],
+    include_package_data=True,
+    install_requires=[],
+    entry_points={
+        'console_scripts': [
+            'runserver=server:run',
+        ],
+    },
+)


### PR DESCRIPTION
This PR adds a lightweight HTTP server built using Python’s standard library. The server exposes a `/datetime` REST API endpoint that returns the current date and time, with optional filters to alter days, weeks, months, and years.